### PR TITLE
Add timezone to verification timestamps

### DIFF
--- a/routes/scanRoutes.js
+++ b/routes/scanRoutes.js
@@ -1407,7 +1407,7 @@ router.post('/api/send-verification-email', isAuthenticated, async (req, res) =>
 
         doc.font('Helvetica').fontSize(9)
            .text(`${getTranslation('pdf-reference', pdfLanguage)} ${referenceNumber} | ${getTranslation('pdf-treatment-date', pdfLanguage)} ${treatmentDate}`, { align: 'center' });
-        doc.text(`${getTranslation('pdf-verified', pdfLanguage)} ${new Date(timestamp).toLocaleString()}`, { align: 'center' });
+        doc.text(`${getTranslation('pdf-verified', pdfLanguage)} ${new Date(timestamp).toLocaleString('en-GB', { timeZoneName: 'short' })}`, { align: 'center' });
         doc.moveDown(2);
 
         // Add verification results section - Arial 9pt italics header, Arial 9pt content
@@ -1545,7 +1545,7 @@ router.post('/api/send-verification-email', isAuthenticated, async (req, res) =>
         doc.text(`${getTranslation('pdf-institution', pdfLanguage)} ${prcData.institutionName !== 'N/A' ? prcData.institutionName : 'Healthcare Provider'}`);
         doc.text(`${getTranslation('pdf-institution-id-signature', pdfLanguage)} ${prcData.institutionId}`);
         doc.text(`${getTranslation('pdf-verified-on', pdfLanguage)} ${new Date(timestamp).toLocaleDateString('en-GB')}`);
-        doc.text(`${getTranslation('pdf-time', pdfLanguage)} ${new Date(timestamp).toLocaleTimeString('en-GB')}`);
+        doc.text(`${getTranslation('pdf-time', pdfLanguage)} ${new Date(timestamp).toLocaleTimeString('en-GB', { timeZoneName: 'short' })}`);
 
         // Finalize PDF
         doc.end();
@@ -1615,7 +1615,7 @@ router.post('/api/send-verification-email', isAuthenticated, async (req, res) =>
             <h2>${getTranslation('email-title', userLanguage, { status: statusText })}</h2>
             <p><strong>${getTranslation('email-reference-number', userLanguage)}</strong> ${referenceNumber}</p>
             <p><strong>${getTranslation('email-treatment-date', userLanguage)}</strong> ${treatmentDate}</p>
-            <p><strong>${getTranslation('email-verification-time', userLanguage)}</strong> ${new Date(timestamp).toLocaleString()}</p>
+            <p><strong>${getTranslation('email-verification-time', userLanguage)}</strong> ${new Date(timestamp).toLocaleString('en-GB', { timeZoneName: 'short' })}</p>
             <hr>
             ${identityVerificationWarning}
             <h3>${getTranslation('email-verification-status', userLanguage, { icon: statusIcon, status: statusText })}</h3>


### PR DESCRIPTION
## Summary
- Added timezone information to all verification timestamps in PDF and email outputs
- Timestamps now display with timezone abbreviation (e.g., GMT, UTC)

## Changes
- PDF header timestamp: Added `timeZoneName: 'short'` to `toLocaleString()`
- PDF verification info time: Added `timeZoneName: 'short'` to `toLocaleTimeString()`
- Email verification time: Added `timeZoneName: 'short'` to `toLocaleString()`

## Test plan
- [ ] Generate a verification PDF and verify timezone is displayed in header
- [ ] Check PDF verification information section shows timezone with time
- [ ] Verify email contains timezone in verification time

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)