### PR TITLE
Add bilingual PDF support for verification emails

### DIFF
--- a/routes/scanRoutes.js
+++ b/routes/scanRoutes.js
@@ -1538,6 +1538,346 @@ router.post('/api/send-verification-email', isAuthenticated, async (req, res) =>
         // Wait for PDF to be written
         await new Promise(resolve => setTimeout(resolve, 500));
 
+        // Generate second PDF in user's UI language if different from issuing country language
+        let secondPdfPath = null;
+        let secondPdfFileName = null;
+
+        if (userLanguage && userLanguage !== pdfLanguage) {
+            logger.info('Generating second PDF in user language', {
+                userLanguage,
+                pdfLanguage
+            });
+
+            // Generate second PDF with user's language
+            secondPdfFileName = `verification-${referenceNumber}-${userLanguage}.pdf`;
+            secondPdfPath = path.join(__dirname, '..', 'temp', secondPdfFileName);
+
+            const doc2 = new PDFDocument();
+            doc2.pipe(fs.createWriteStream(secondPdfPath));
+
+            // Use userLanguage for all translations in the second PDF
+            const lang2 = userLanguage;
+
+            // Move up to reduce top margin before main title
+            doc2.moveUp(2.5);
+
+            // Main titles
+            doc2.font('Helvetica-Bold').fontSize(12)
+               .text(getTranslation('pdf-title1', lang2), { align: 'center' });
+            doc2.text(getTranslation('pdf-title2', lang2), { align: 'center' });
+            doc2.text(getTranslation('pdf-title3', lang2), { align: 'center' });
+
+            // Subtitles
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-subtitle1', lang2), { align: 'center' });
+            doc2.text(getTranslation('pdf-subtitle2', lang2), { align: 'center' });
+            doc2.moveDown(1);
+
+            // Calculate page dimensions
+            const pageWidth2 = doc2.page.width - doc2.page.margins.left - doc2.page.margins.right;
+            const leftMargin2 = doc2.page.margins.left;
+            const fullPageWidth2 = doc2.page.width - leftMargin2 - doc2.page.margins.right;
+
+            // Right-aligned section header
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-issuing-member-state', lang2), { align: 'right' });
+            doc2.moveDown(0.5);
+
+            // Create bordered text boxes for fields 1 and 2
+            const currentY2 = doc2.y;
+            const boxHeight2 = 30;
+            const box1Width2 = pageWidth2 * 0.48;
+            const box2Width2 = pageWidth2 * 0.48;
+            const box2X2 = doc2.x + pageWidth2 * 0.52;
+
+            doc2.lineWidth(0.5);
+            doc2.rect(doc2.x, currentY2, box1Width2, boxHeight2).stroke();
+            doc2.font('Helvetica').fontSize(9).text('1.', doc2.x + 5, currentY2 + 10);
+            doc2.rect(box2X2, currentY2, box2Width2, boxHeight2).stroke();
+            doc2.text(`2. ${prcData.issuingMemberState}`, box2X2 + 5, currentY2 + 10);
+            doc2.y = currentY2 + boxHeight2 + 10;
+
+            // Card holder information
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-card-holder-info', lang2), leftMargin2, doc2.y);
+            doc2.moveDown(0.5);
+
+            let fieldY2 = doc2.y;
+            const groupBoxHeight2 = 80;
+            doc2.lineWidth(0.5);
+            doc2.rect(leftMargin2, fieldY2, fullPageWidth2, groupBoxHeight2).stroke();
+
+            const fieldLeftMargin2 = leftMargin2 + 5;
+            doc2.font('Helvetica').fontSize(9)
+               .text(`3. ${getTranslation('pdf-name-field', lang2)} ${prcData.cardHolderName}`, fieldLeftMargin2, fieldY2 + 8);
+            doc2.text(`4. ${getTranslation('pdf-given-name-field', lang2)} ${prcData.cardHolderGivenName}`, fieldLeftMargin2, fieldY2 + 28);
+            doc2.text(`5. ${getTranslation('pdf-date-of-birth-field', lang2)} ${prcData.dateOfBirth}`, fieldLeftMargin2, fieldY2 + 48);
+            doc2.text(`6. ${getTranslation('pdf-personal-id-field', lang2)} ${prcData.personalIdNumber}`, fieldLeftMargin2, fieldY2 + 68);
+            doc2.y = fieldY2 + groupBoxHeight2 + 10;
+
+            // Competent institution information
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-competent-institution-info', lang2), leftMargin2, doc2.y);
+            doc2.moveDown(0.5);
+
+            fieldY2 = doc2.y;
+            const institutionBoxHeight2 = 35;
+            doc2.lineWidth(0.5);
+            doc2.rect(leftMargin2, fieldY2, fullPageWidth2, institutionBoxHeight2).stroke();
+            doc2.font('Helvetica').fontSize(9);
+            doc2.text(`7. ${getTranslation('pdf-institution-id-field', lang2)}`, leftMargin2 + 5, fieldY2 + 5);
+
+            let institutionData2 = "";
+            if (prcData.institutionId !== 'N/A' && prcData.institutionName !== 'N/A') {
+                institutionData2 = `    ${prcData.institutionId} - ${prcData.institutionName}`;
+            } else if (prcData.institutionId !== 'N/A') {
+                institutionData2 = `    ${prcData.institutionId}`;
+            } else if (prcData.institutionName !== 'N/A') {
+                institutionData2 = `    ${prcData.institutionName}`;
+            } else {
+                institutionData2 = `    N/A`;
+            }
+
+            doc2.text(institutionData2, leftMargin2 + 5, fieldY2 + 5 + 12 + 3.15, { width: fullPageWidth2 - 10 });
+            doc2.moveDown(0.5);
+            doc2.y = fieldY2 + institutionBoxHeight2 + 10;
+
+            // Card information
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-card-info', lang2), leftMargin2, doc2.y);
+            doc2.moveDown(0.5);
+
+            fieldY2 = doc2.y;
+            const combinedBoxHeight2 = 45;
+            doc2.lineWidth(0.5);
+            doc2.rect(leftMargin2, fieldY2, fullPageWidth2, combinedBoxHeight2).stroke();
+            doc2.font('Helvetica').fontSize(9)
+               .text(`8. ${getTranslation('pdf-card-id-field', lang2)} ${prcData.cardId}`, leftMargin2 + 5, fieldY2 + 8);
+            doc2.text(`9. ${getTranslation('pdf-expiry-date-field', lang2)} ${prcData.expiryDate}`, leftMargin2 + 5, fieldY2 + 28);
+            doc2.y = fieldY2 + combinedBoxHeight2 + 10;
+
+            // Certificate validity and delivery date
+            const validityBoxWidth2 = fullPageWidth2 * 0.48;
+            const deliveryBoxWidth2 = fullPageWidth2 * 0.48;
+            const deliveryBoxX2 = leftMargin2 + fullPageWidth2 * 0.52;
+            const splitBoxHeight2 = 50;
+            const headerY2 = doc2.y;
+
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-certificate-validity-period', lang2), leftMargin2, headerY2);
+            doc2.text(getTranslation('pdf-certificate-delivery-date', lang2), deliveryBoxX2, headerY2);
+            doc2.moveDown(0.5);
+
+            fieldY2 = doc2.y;
+            doc2.lineWidth(0.5);
+            doc2.rect(leftMargin2, fieldY2, validityBoxWidth2, splitBoxHeight2).stroke();
+            doc2.rect(deliveryBoxX2, fieldY2, deliveryBoxWidth2, splitBoxHeight2).stroke();
+
+            doc2.font('Helvetica').fontSize(9)
+               .text(`(a). ${getTranslation('pdf-from-field', lang2)} ${prcData.validityStart}`, leftMargin2 + 5, fieldY2 + 8);
+            doc2.text(`(b). ${getTranslation('pdf-to-field', lang2)} ${prcData.validityEnd}`, leftMargin2 + 5, fieldY2 + 28);
+            doc2.text(`(c). ${prcData.deliveryDate}`, deliveryBoxX2 + 5, fieldY2 + 18);
+            doc2.y = fieldY2 + splitBoxHeight2 + 10;
+
+            // Signature section with QR code
+            const signatureHeaderX2 = leftMargin2 + (pageWidth2 * 0.52);
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-signature-stamp', lang2), signatureHeaderX2, doc2.y);
+            doc2.moveDown();
+
+            const signatureBoxY2 = doc2.y;
+            const signatureBoxHeight2 = 160;
+            const signatureBoxWidth2 = pageWidth2 * 0.35;
+            const signatureBoxX2 = leftMargin2 + (pageWidth2 * 0.52);
+
+            doc2.lineWidth(0.5);
+            doc2.rect(signatureBoxX2, signatureBoxY2, signatureBoxWidth2, signatureBoxHeight2).stroke();
+
+            // Add QR code
+            if (verificationData) {
+                try {
+                    const optimalQR2 = await generateOptimalQRCodeForPDF(verificationData);
+                    if (optimalQR2.success) {
+                        const baseSize2 = 150;
+                        const scaleFactor2 = Math.max(1, Math.min(2, baseSize2 / optimalQR2.moduleCount));
+                        const qrCodeSize2 = Math.min(150, optimalQR2.moduleCount * scaleFactor2);
+                        const qrCodeX2 = signatureBoxX2 + (signatureBoxWidth2 - qrCodeSize2) / 2;
+                        const qrCodeY2 = signatureBoxY2 + (signatureBoxHeight2 - qrCodeSize2) / 2;
+
+                        const sharp = require('sharp');
+                        const svgBuffer2 = Buffer.from(optimalQR2.svgString);
+                        const pngBuffer2 = await sharp(svgBuffer2)
+                            .png({ quality: 100, compressionLevel: 0 })
+                            .resize(qrCodeSize2 * 3, qrCodeSize2 * 3)
+                            .toBuffer();
+
+                        doc2.image(pngBuffer2, qrCodeX2, qrCodeY2, {
+                            width: qrCodeSize2,
+                            height: qrCodeSize2,
+                            fit: [qrCodeSize2, qrCodeSize2]
+                        });
+                    }
+                } catch (qrError2) {
+                    logger.error('Failed to generate QR code for second PDF', { error: qrError2.message });
+                }
+            }
+
+            doc2.y = signatureBoxY2 + signatureBoxHeight2 + 15;
+
+            // Horizontal ruler
+            doc2.moveTo(leftMargin2, doc2.y)
+               .lineTo(leftMargin2 + pageWidth2, doc2.y)
+               .lineWidth(0.5)
+               .stroke();
+            doc2.moveDown(0.5);
+
+            // Notes section
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-notes-title', lang2), leftMargin2, doc2.y);
+            doc2.moveDown(0.3);
+            doc2.font('Helvetica').fontSize(9)
+               .text(getTranslation('pdf-notes-text', lang2), leftMargin2, doc2.y, {
+                width: pageWidth2,
+                align: 'justify'
+            });
+
+            // Page 2: Verification Status
+            doc2.addPage();
+
+            let hasErrors2 = false;
+            let hasWarnings2 = false;
+            if (verificationStatus?.validationSummary) {
+                Object.values(verificationStatus.validationSummary).forEach(validation => {
+                    if (validation && typeof validation === 'object') {
+                        if (validation.status === 'error') hasErrors2 = true;
+                        if (validation.status === 'warning') hasWarnings2 = true;
+                    }
+                });
+            }
+
+            let pdfOverallStatusText2;
+            let pdfStatusSymbol2;
+            if (hasErrors2) {
+                pdfOverallStatusText2 = getTranslation('pdf-verification-rejected', lang2);
+                pdfStatusSymbol2 = '❌';
+            } else {
+                pdfOverallStatusText2 = getTranslation('pdf-verification-approved', lang2);
+                pdfStatusSymbol2 = '✅';
+            }
+
+            doc2.font('Helvetica-Bold').fontSize(12)
+               .text(`${getTranslation('pdf-verification', lang2)} ${pdfStatusSymbol2} ${pdfOverallStatusText2}`, { align: 'center' });
+
+            if (hasWarnings2 && !hasErrors2) {
+                doc2.font('Helvetica').fontSize(10)
+                   .text(`⚠️ ${getTranslation('pdf-optional-warnings', lang2)}`, { align: 'center' });
+            }
+
+            doc2.font('Helvetica').fontSize(9)
+               .text(`${getTranslation('pdf-reference', lang2)} ${referenceNumber} | ${getTranslation('pdf-treatment-date', lang2)} ${treatmentDate}`, { align: 'center' });
+            doc2.text(`${getTranslation('pdf-verified', lang2)} ${new Date(timestamp).toLocaleString('en-GB', { timeZoneName: 'short' })}`, { align: 'center' });
+            doc2.moveDown(2);
+
+            doc2.font('Helvetica-Oblique').fontSize(9)
+               .text(getTranslation('pdf-verification-results', lang2), { align: 'center' });
+            doc2.moveDown();
+            doc2.font('Helvetica').fontSize(9);
+            const passedText2 = getTranslation('email-passed', lang2);
+            const failedText2 = getTranslation('email-failed', lang2);
+
+            // Identity verification warning
+            if (identityVerification) {
+                try {
+                    const identityData2 = JSON.parse(identityVerification);
+                    let warningMessages2 = [];
+                    if (!identityData2.identityVerified) warningMessages2.push('Identity (name) verification was skipped');
+                    if (!identityData2.birthdateVerified) warningMessages2.push('Birthdate verification was skipped');
+
+                    if (warningMessages2.length > 0) {
+                        const pageWidth2Val = doc2.page.width;
+                        const margin2 = 50;
+                        const boxWidth2Val = pageWidth2Val - (margin2 * 2);
+                        const boxHeight2Val = 30 + (warningMessages2.length > 1 ? 15 : 0);
+                        const currentY2Val = doc2.y;
+
+                        doc2.rect(margin2, currentY2Val, boxWidth2Val, boxHeight2Val)
+                           .fillAndStroke('#FFE4B5', '#FFA500');
+                        doc2.fillColor('#B8860B').font('Helvetica-Bold').fontSize(10);
+
+                        let textY2 = currentY2Val + 8;
+                        warningMessages2.forEach((msg) => {
+                            doc2.text(`WARNING: ${msg}`, margin2 + 10, textY2, {
+                                width: boxWidth2Val - 20,
+                                align: 'center'
+                            });
+                            textY2 += 15;
+                        });
+
+                        doc2.fillColor('black').font('Helvetica').fontSize(9);
+                        doc2.y = currentY2Val + boxHeight2Val + 10;
+                    }
+                } catch (e) {
+                    logger.error('Could not parse identity verification data for second PDF');
+                }
+            }
+
+            // Technical Validations
+            doc2.font('Helvetica-Bold').fontSize(10).text('TECHNICAL VALIDATIONS', { align: 'left' });
+            doc2.moveDown(0.5);
+            doc2.font('Helvetica').fontSize(9);
+            doc2.text(`${statusSymbol('qrCodeAnalysis', 'qrCodeAnalysis')} QR Code Analysis: ${getValidationStatus('qrCodeAnalysis', 'qrCodeAnalysis') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('base45Decode', 'base45Decode')} BASE45 Decoding: ${getValidationStatus('base45Decode', 'base45Decode') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('zlibDecompress', 'zlibDecompression')} ZLIB Decompression: ${getValidationStatus('zlibDecompress', 'zlibDecompression') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('jwtParsing', 'jwtParsing')} JWT Parsing: ${getValidationStatus('jwtParsing', 'jwtParsing') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('schemaFileCheck', 'schemaFileCheck')} Schema File Check: ${getValidationStatus('schemaFileCheck', 'schemaFileCheck') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('schemaValidation', 'schemaValidation')} Schema Validation: ${getValidationStatus('schemaValidation', 'schemaValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('kidHeaderValidation', 'kidHeaderValidation')} Kid Header Validation: ${getValidationStatus('kidHeaderValidation', 'kidHeaderValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('algorithmHeaderValidation', 'algorithmHeaderValidation')} Algorithm Header Validation: ${getValidationStatus('algorithmHeaderValidation', 'algorithmHeaderValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('signatureVerification', 'certificateAuthority')} Signature Retrieval: ${getValidationStatus('signatureVerification', 'certificateAuthority') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('signatureCountValidation', 'signatureCountValidation')} Signature Count Validation: ${getValidationStatus('signatureCountValidation', 'signatureCountValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('countryCodeValidation', 'countryCodeValidation')} Country Code Validation: ${getValidationStatus('countryCodeValidation', 'countryCodeValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('officialIdValidation', 'officialIdValidation')} Official ID Validation: ${getValidationStatus('officialIdValidation', 'officialIdValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('jwtSignatureValidation', 'signatureVerification')} JWT Signature Validation: ${getValidationStatus('jwtSignatureValidation', 'signatureVerification') ? passedText2 : failedText2}`);
+            doc2.moveDown(1);
+
+            // Business Validations
+            doc2.font('Helvetica-Bold').fontSize(10).text('BUSINESS VALIDATIONS', { align: 'left' });
+            doc2.moveDown(0.5);
+            doc2.font('Helvetica').fontSize(9);
+            doc2.text(`${statusSymbol('certificateValidityDate', 'certificateValidityDate')} Certificate Validity Date: ${getValidationStatus('certificateValidityDate', 'certificateValidityDate') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('ehicAccreditation', 'ehicAccreditation')} EHIC Accreditation: ${getValidationStatus('ehicAccreditation', 'ehicAccreditation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('dateOfBirthValidation', 'dateOfBirthValidation')} Date of Birth Validation: ${getValidationStatus('dateOfBirthValidation', 'dateOfBirthValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('dateRangeValidation', 'dateRangeValidation')} Start/End Date Validation: ${getValidationStatus('dateRangeValidation', 'dateRangeValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('startIssuanceValidation', 'startIssuanceValidation')} Start/Issuance Date Validation: ${getValidationStatus('startIssuanceValidation', 'startIssuanceValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('issuanceEndValidation', 'issuanceEndValidation')} Issuance/End Date Validation: ${getValidationStatus('issuanceEndValidation', 'issuanceEndValidation') ? passedText2 : failedText2}`);
+            doc2.text(`${statusSymbol('expiryDateValidation', 'expiryDateValidation')} Expiry Date Validation: ${getValidationStatus('expiryDateValidation', 'expiryDateValidation') ? passedText2 : getValidationSkipped('expiryDateValidation') ? 'skipped - no expiry date found' : failedText2}`);
+            doc2.text(`${statusSymbol('institutionLengthValidation', 'institutionLengthValidation')} Institution Length Validation (Optional): ${getValidationStatus('institutionLengthValidation', 'institutionLengthValidation') ? passedText2 : getValidationSkipped('institutionLengthValidation') ? 'skipped - no expiry date found' : failedText2}`);
+            doc2.text(`${statusSymbol('cardIdDigitValidation', 'cardIdDigitValidation')} Card ID Digit Validation (Optional): ${getValidationStatus('cardIdDigitValidation', 'cardIdDigitValidation') ? passedText2 : getValidationSkipped('cardIdDigitValidation') ? 'skipped - no card id found' : failedText2}`);
+            doc2.text(`${statusSymbol('institutionIdDigitValidation', 'institutionIdDigitValidation')} Institution ID Digit Validation (Optional): ${getValidationStatus('institutionIdDigitValidation', 'institutionIdDigitValidation') ? passedText2 : getValidationSkipped('institutionIdDigitValidation') ? 'skipped - no institution id found' : failedText2}`);
+            doc2.moveDown(1);
+
+            // Revocation Validations
+            doc2.font('Helvetica-Bold').fontSize(10).text('REVOCATION VALIDATIONS', { align: 'left' });
+            doc2.moveDown(0.5);
+            doc2.font('Helvetica').fontSize(9);
+            doc2.text(`${statusSymbol('revocationPresence', 'revocationPresence')} Revocation Information Presence: ${getValidationStatus('revocationPresence', 'revocationPresence') ? passedText2 : getValidationSkipped('revocationPresence') ? 'skipped - no revocation data' : failedText2}`);
+            doc2.text(`${statusSymbol('revocationStatus', 'revocationStatus')} Revocation Status Check: ${getValidationStatus('revocationStatus', 'revocationStatus') ? passedText2 : getValidationSkipped('revocationStatus') ? 'skipped - no revocation data' : failedText2}`);
+            doc2.moveDown(1);
+
+            // Treatment Date Validations
+            doc2.font('Helvetica-Bold').fontSize(10).text('TREATMENT DATE VALIDATIONS', { align: 'left' });
+            doc2.moveDown(0.5);
+            doc2.font('Helvetica').fontSize(9);
+            doc2.text(`${statusSymbol('treatmentDatePresence', 'treatmentDatePresence')} Treatment Date Presence: ${getValidationStatus('treatmentDatePresence', 'treatmentDatePresence') ? passedText2 : getValidationSkipped('treatmentDatePresence') ? 'skipped - no treatment date' : failedText2}`);
+            doc2.text(`${statusSymbol('treatmentDateRange', 'treatmentDateRange')} Treatment Date Range Validation: ${getValidationStatus('treatmentDateRange', 'treatmentDateRange') ? passedText2 : getValidationSkipped('treatmentDateRange') ? 'skipped - no treatment date' : failedText2}`);
+            doc2.moveDown(2);
+
+            doc2.end();
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            logger.info('Second PDF generated successfully in user language', { userLanguage });
+        }
+
         // Determine overall status - check for errors and warnings
         let emailHasErrors = false;
         let emailHasWarnings = false;
@@ -1765,6 +2105,34 @@ router.post('/api/send-verification-email', isAuthenticated, async (req, res) =>
         const pdfContent = fs.readFileSync(pdfPath);
         const jsonContent = fs.readFileSync(jsonPath);
 
+        // Prepare attachments array
+        const attachments = [
+            {
+                filename: pdfFileName,
+                content: pdfContent,
+                contentType: 'application/pdf'
+            },
+            {
+                filename: jsonFileName,
+                content: jsonContent,
+                contentType: 'application/json'
+            }
+        ];
+
+        // Add second PDF if it was generated
+        if (secondPdfPath && fs.existsSync(secondPdfPath)) {
+            const secondPdfContent = fs.readFileSync(secondPdfPath);
+            attachments.push({
+                filename: secondPdfFileName,
+                content: secondPdfContent,
+                contentType: 'application/pdf'
+            });
+            logger.info('Added second PDF to email attachments', {
+                filename: secondPdfFileName,
+                language: userLanguage
+            });
+        }
+
         // Send email with PDF and JSON attachments
         await transporter.sendMail({
             from: '"EHIC Verifier" <noreply@zandd.eu>',
@@ -1774,23 +2142,16 @@ router.post('/api/send-verification-email', isAuthenticated, async (req, res) =>
                 status: statusText
             }),
             html: emailHTML,
-            attachments: [
-                {
-                    filename: pdfFileName,
-                    content: pdfContent,
-                    contentType: 'application/pdf'
-                },
-                {
-                    filename: jsonFileName,
-                    content: jsonContent,
-                    contentType: 'application/json'
-                }
-            ]
+            attachments: attachments
         });
 
         // Clean up temp files
         fs.unlinkSync(pdfPath);
         fs.unlinkSync(jsonPath);
+        if (secondPdfPath && fs.existsSync(secondPdfPath)) {
+            fs.unlinkSync(secondPdfPath);
+            logger.info('Cleaned up second PDF temp file', { filename: secondPdfFileName });
+        }
         
 
         // For demonstration, we'll save the email request to the database


### PR DESCRIPTION
## Summary
- Implemented bilingual PDF generation for verification emails
- First PDF generated in issuing country's official language (based on member state)
- Second PDF generated in user's UI language if different from issuing country language
- Both PDFs attached to email when languages differ

## Changes
- Added conditional second PDF generation after first PDF completes
- Second PDF uses user's UI language for all translations
- Updated email attachments to include both PDFs when applicable
- Filenames distinguish language: `verification-{ref}.pdf` and `verification-{ref}-{lang}.pdf`
- Automatic cleanup of both PDF temp files after email is sent

## Example Scenarios
**Scenario 1: Different languages**
- User UI language: English (en)
- EHIC issuing country: Germany (DE → de)
- Result: 2 PDFs attached (German and English)

**Scenario 2: Same language**
- User UI language: French (fr)
- EHIC issuing country: France (FR → fr)
- Result: 1 PDF attached (French only)

## Technical Details
- Added 373 lines of PDF generation code for second PDF
- Uses same validation data and PRC data as first PDF
- Only translation language differs between the two PDFs
- Logging added for second PDF generation, attachment, and cleanup

## Test plan
- [ ] Test with EHIC from different country than UI language
- [ ] Verify two PDFs are attached to email
- [ ] Verify first PDF is in issuing country language
- [ ] Verify second PDF is in UI language
- [ ] Test with same country and UI language (should generate only one PDF)
- [ ] Verify temp files are cleaned up after email is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)