### PR TITLE
Change button text from 'Identity Check' to 'Visual Verification'

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -104,7 +104,7 @@
     "results-verification-successful": "Verification Successful",
     "results-verification-failed": "Verification Failed",
     "results-continue-finalize": "Continue to Finalize Verification",
-    "results-continue-identity": "Continue to Identity Check",
+    "results-continue-identity": "Continue to Visual Verification",
     "results-network-error": "Network Error",
     "results-unknown-error": "Unknown error",
     "results-qr-data-received": "QR code data received successfully",


### PR DESCRIPTION
## Summary
- Updated the results page button text to better reflect the verification process
- Changed English translation from "Continue to Identity Check" to "Continue to Visual Verification"
- This aligns with existing terminology used throughout the application (e.g., "Visual Verification" title on the identity page)

## Changes
- Modified `public/lang/en.json`: Updated `results-continue-identity` translation key

## Test plan
- [x] Navigate to http://localhost:3000/results after QR code scan
- [x] Verify button text displays "Continue to Visual Verification"
- [x] Click button and confirm it navigates to the visual verification page
- [x] Verify the change is consistent with the rest of the application terminology

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)