### PR TITLE
Add version display to footer alongside copyright

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1457,9 +1457,43 @@ body {
 .footer {
     background-color: var(--dark-color);
     color: white;
-    text-align: center;
     padding: 1rem;
     margin-top: auto;
+}
+
+.footer-content {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+    position: relative;
+}
+
+.footer-left {
+    text-align: center;
+}
+
+.footer-right {
+    position: absolute;
+    right: 0;
+    font-family: monospace;
+    font-size: 0.9em;
+    opacity: 0.8;
+}
+
+/* Mobile responsive footer */
+@media (max-width: 480px) {
+    .footer-content {
+        flex-direction: column;
+        gap: 0.5rem;
+        text-align: center;
+    }
+
+    .footer-right {
+        position: static;
+        right: auto;
+    }
 }
 
 .mobile-scanner-header {

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const bodyParser = require('body-parser');
 const path = require('path');
 const session = require('express-session');
 const MongoStore = require('connect-mongo');
+const packageJson = require('./package.json');
 require('dotenv').config();
 
 const app = express();
@@ -94,11 +95,12 @@ app.use((req, res, next) => {
 const APP_MODE = (process.env.MODE || 'DEBUG').toUpperCase();
 console.log(`Application running in ${APP_MODE} mode`);
 
-// Make mode available to all views
+// Make mode and version available to all views
 app.use((req, res, next) => {
   res.locals.appMode = APP_MODE;
   res.locals.isDebugMode = APP_MODE === 'DEBUG';
   res.locals.isProductionMode = APP_MODE === 'PRODUCTION';
+  res.locals.appVersion = packageJson.version;
   next();
 });
 

--- a/views/layouts/footer.ejs
+++ b/views/layouts/footer.ejs
@@ -1,3 +1,6 @@
 <footer class="footer">
-    <p data-i18n-key="footer-copyright">&copy; 2025 European Commission</p>
+    <div class="footer-content">
+        <span class="footer-left" data-i18n-key="footer-copyright">&copy; 2025 European Commission</span>
+        <span class="footer-right">v<%= appVersion %></span>
+    </div>
 </footer>


### PR DESCRIPTION
## Summary
- Implements version display from package.json in the application footer
- Copyright text is centered, version is right-aligned
- Responsive design for mobile devices

## Changes Made
- **Server.js**: Added `appVersion` to global middleware for all views
- **Footer.ejs**: Updated template to display version alongside copyright  
- **Style.css**: Implemented centered copyright with right-aligned version layout
- **Mobile Responsive**: Added CSS media queries for proper mobile display

## Layout Details
- Copyright: "© 2025 European Commission" (centered)
- Version: "v0.28.1" (right-aligned, monospace font)
- Mobile: Stacked vertically and centered

## Testing
- Verified footer appears correctly on all main application pages
- Tested responsive behavior on mobile screen sizes
- Confirmed version reads from package.json (v0.28.1)

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)