### PR TITLE
feat: Remove print summary button from finalization page

### DIFF
--- a/public/js/finalization.js
+++ b/public/js/finalization.js
@@ -279,10 +279,7 @@ document.getElementById('send-email').addEventListener('click', async () => {
     }
 });
 
-// Print functionality
-document.getElementById('print-summary').addEventListener('click', () => {
-    window.print();
-});
+// Print functionality removed - print summary button no longer available
 
 // PDF Print functionality
 document.getElementById('print-pdf').addEventListener('click', async () => {

--- a/public/lang/bg.json
+++ b/public/lang/bg.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Въведете имейл адрес",
     "finalization-send-email": "Изпращане на имейл",
     "finalization-sending": "Изпращане...",
-    "finalization-print-summary": "Печат на резюмето",
     "finalization-start-new-verification": "Стартиране на нова верификация",
     "finalization-email-success": "✅ Резюмето на верификацията е изпратено успешно до {email}",
     "finalization-email-error": "Изпращането на имейла се провали. Моля, опитайте отново.",

--- a/public/lang/cs.json
+++ b/public/lang/cs.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Zadejte e-mailovou adresu",
     "finalization-send-email": "Odeslat E-mail",
     "finalization-sending": "Odesílání...",
-    "finalization-print-summary": "Vytisknout Souhrn",
     "finalization-start-new-verification": "Zahájit Nové Ověření",
     "finalization-email-success": "✅ Souhrn ověření úspěšně odeslán na {email}",
     "finalization-email-error": "Odeslání e-mailu selhalo. Zkuste to prosím znovu.",

--- a/public/lang/da.json
+++ b/public/lang/da.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Indtast e-mailadresse",
     "finalization-send-email": "Send E-mail",
     "finalization-sending": "Sender...",
-    "finalization-print-summary": "Udskriv Sammendrag",
     "finalization-start-new-verification": "Start Ny Verificering",
     "finalization-email-success": "✅ Verificeringssammendrag sendt succesfuldt til {email}",
     "finalization-email-error": "Mislykkedes at sende e-mail. Prøv venligst igen.",

--- a/public/lang/de.json
+++ b/public/lang/de.json
@@ -136,7 +136,6 @@
     "finalization-enter-email": "E-Mail-Adresse eingeben",
     "finalization-send-email": "E-Mail senden",
     "finalization-sending": "Wird gesendet...",
-    "finalization-print-summary": "Zusammenfassung drucken",
     "finalization-start-new-verification": "Neue Verifizierung starten",
     "finalization-email-success": "✅ Verifizierungszusammenfassung erfolgreich an {email} gesendet",
     "finalization-email-error": "E-Mail-Versand fehlgeschlagen. Bitte versuchen Sie es erneut.",

--- a/public/lang/el.json
+++ b/public/lang/el.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Εισάγετε διεύθυνση email",
     "finalization-send-email": "Αποστολή email",
     "finalization-sending": "Αποστέλλεται...",
-    "finalization-print-summary": "Εκτύπωση περίληψης",
     "finalization-start-new-verification": "Εκκίνηση νέας επαλήθευσης",
     "finalization-email-success": "✅ Η περίληψη επαλήθευσης στάλθηκε με επιτυχία στο {email}",
     "finalization-email-error": "Η αποστολή email απέτυχε. Παρακαλώ δοκιμάστε ξανά.",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -154,7 +154,6 @@
     "finalization-enter-email": "Enter email address",
     "finalization-send-email": "Send Email",
     "finalization-sending": "Sending...",
-    "finalization-print-summary": "Print Summary",
     "finalization-print-pdf": "Print PDF",
     "finalization-print-pdf-bilingual": "Print PDF (Bilingual)",
     "finalization-generating-pdf": "Generating PDF...",

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -136,7 +136,6 @@
     "finalization-enter-email": "Ingrese dirección de email",
     "finalization-send-email": "Enviar Email",
     "finalization-sending": "Enviando...",
-    "finalization-print-summary": "Imprimir Resumen",
     "finalization-start-new-verification": "Iniciar Nueva Verificación",
     "finalization-email-success": "✅ Resumen de verificación enviado exitosamente a {email}",
     "finalization-email-error": "Falló el envío de email. Por favor, intente nuevamente.",

--- a/public/lang/et.json
+++ b/public/lang/et.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Sisestage e-posti aadress",
     "finalization-send-email": "Saada e-post",
     "finalization-sending": "Saatmine...",
-    "finalization-print-summary": "Prindi kokkuvõte",
     "finalization-start-new-verification": "Alusta uut kinnitamist",
     "finalization-email-success": "✅ Kinnitamise kokkuvõte edukalt saadetud aadressile {email}",
     "finalization-email-error": "E-posti saatmine ebaõnnestus. Palun proovige uuesti.",

--- a/public/lang/fi.json
+++ b/public/lang/fi.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Syötä sähköpostiosoite",
     "finalization-send-email": "Lähetä Sähköposti",
     "finalization-sending": "Lähetetään...",
-    "finalization-print-summary": "Tulosta Yhteenveto",
     "finalization-start-new-verification": "Aloita Uusi Vahvistus",
     "finalization-email-success": "✅ Vahvistusyhteenveto lähetetty onnistuneesti osoitteeseen {email}",
     "finalization-email-error": "Sähköpostin lähettäminen epäonnistui. Yritä uudelleen.",

--- a/public/lang/fr.json
+++ b/public/lang/fr.json
@@ -136,7 +136,6 @@
     "finalization-enter-email": "Saisissez l'adresse email",
     "finalization-send-email": "Envoyer l'email",
     "finalization-sending": "Envoi en cours...",
-    "finalization-print-summary": "Imprimer le résumé",
     "finalization-start-new-verification": "Commencer une nouvelle vérification",
     "finalization-email-success": "✅ Résumé de vérification envoyé avec succès à {email}",
     "finalization-email-error": "Échec de l'envoi de l'email. Veuillez réessayer.",

--- a/public/lang/fy.json
+++ b/public/lang/fy.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Fier e-mailadres yn",
     "finalization-send-email": "Stjoer E-mail",
     "finalization-sending": "Stjoere...",
-    "finalization-print-summary": "Print Gearfetting",
     "finalization-start-new-verification": "Start Nije Ferifikaasje",
     "finalization-email-success": "✅ Ferifikaasje gearfetting mei sukses stjoerd nei {email}",
     "finalization-email-error": "E-mail stjoeren mislearre. Probearje opnij.",

--- a/public/lang/ga.json
+++ b/public/lang/ga.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Cuir isteach seoladh ríomhphoist",
     "finalization-send-email": "Seol Ríomhphost",
     "finalization-sending": "Ag seoladh...",
-    "finalization-print-summary": "Priontáil Achoimre",
     "finalization-start-new-verification": "Tosaigh Fíorúchán Nua",
     "finalization-email-success": "✅ Achoimre fíorúcháin seolta go rathúil chuig {email}",
     "finalization-email-error": "Theip ar sheoladh ríomhphoist. Triail arís.",

--- a/public/lang/hr.json
+++ b/public/lang/hr.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Unesite e-mail adresu",
     "finalization-send-email": "Pošaljite e-mail",
     "finalization-sending": "Šalje se...",
-    "finalization-print-summary": "Ispiši sažetak",
     "finalization-start-new-verification": "Započni novu provjeru",
     "finalization-email-success": "✅ Sažetak provjere uspješno poslan na {email}",
     "finalization-email-error": "Slanje e-maila neuspješno. Molimo pokušajte ponovno.",

--- a/public/lang/hu.json
+++ b/public/lang/hu.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Email cím megadása",
     "finalization-send-email": "Email küldése",
     "finalization-sending": "Küldés...",
-    "finalization-print-summary": "Összefoglaló nyomtatása",
     "finalization-start-new-verification": "Új ellenőrzés indítása",
     "finalization-email-success": "✅ Ellenőrzés összefoglaló sikeresen elküldve ide: {email}",
     "finalization-email-error": "Email küldése sikertelen. Kérjük próbálja újra.",

--- a/public/lang/is.json
+++ b/public/lang/is.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Sláðu inn tölvupóstfang",
     "finalization-send-email": "Senda tölvupóst",
     "finalization-sending": "Sendi...",
-    "finalization-print-summary": "Prenta samantekt",
     "finalization-start-new-verification": "Byrja nýja sannprófun",
     "finalization-email-success": "✅ Sannprófunarsamantekt send með góðum árangri til {email}",
     "finalization-email-error": "Tölvupóstursending misheppnaðist. Vinsamlegast reyndu aftur.",

--- a/public/lang/it.json
+++ b/public/lang/it.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Inserire indirizzo email",
     "finalization-send-email": "Invia Email",
     "finalization-sending": "Invio...",
-    "finalization-print-summary": "Stampa Riassunto",
     "finalization-start-new-verification": "Inizia Nuova Verifica",
     "finalization-email-success": "✅ Riassunto della verifica inviato con successo a {email}",
     "finalization-email-error": "Invio email fallito. Si prega di riprovare.",

--- a/public/lang/lt.json
+++ b/public/lang/lt.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Įveskite el. pašto adresą",
     "finalization-send-email": "Siųsti el. paštą",
     "finalization-sending": "Siunčiama...",
-    "finalization-print-summary": "Spausdinti santrauką",
     "finalization-start-new-verification": "Pradėti naują tikrinimą",
     "finalization-email-success": "✅ Tikrinimo santrauka sėkmingai išsiųsta į {email}",
     "finalization-email-error": "El. pašto siuntimas nepavyko. Bandykite dar kartą.",

--- a/public/lang/lv.json
+++ b/public/lang/lv.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Ievadiet e-pasta adresi",
     "finalization-send-email": "Sūtīt e-pastu",
     "finalization-sending": "Sūtu...",
-    "finalization-print-summary": "Drukāt kopsavilkumu",
     "finalization-start-new-verification": "Sākt jaunu verifikāciju",
     "finalization-email-success": "✅ Verifikācijas kopsavilkums veiksmīgi nosūtīts uz {email}",
     "finalization-email-error": "E-pasta sūtīšana neizdevās. Lūdzu mēģiniet vēlreiz.",

--- a/public/lang/mt.json
+++ b/public/lang/mt.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Daħħal l-indirizz tal-email",
     "finalization-send-email": "Ibgħat email",
     "finalization-sending": "Qed nibgħat...",
-    "finalization-print-summary": "Stampa sommarju",
     "finalization-start-new-verification": "Ibda verifika ġdida",
     "finalization-email-success": "✅ Sommarju tal-verifika mibgħut b'suċċess lil {email}",
     "finalization-email-error": "L-email ma rnexxielux jintbagħat. Jekk jogħġbok erġa' pprova.",

--- a/public/lang/nl.json
+++ b/public/lang/nl.json
@@ -122,7 +122,6 @@
     "finalization-enter-email": "Voer e-mailadres in",
     "finalization-send-email": "Verstuur E-mail",
     "finalization-sending": "Versturen...",
-    "finalization-print-summary": "Print Samenvatting",
     "finalization-start-new-verification": "Start Nieuwe Verificatie",
     "finalization-email-success": "✅ Verificatie samenvatting succesvol verzonden naar {email}",
     "finalization-email-error": "Versturen e-mail mislukt. Probeer opnieuw.",

--- a/public/lang/no.json
+++ b/public/lang/no.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Skriv inn e-postadresse",
     "finalization-send-email": "Send E-post",
     "finalization-sending": "Sender...",
-    "finalization-print-summary": "Skriv ut Sammendrag",
     "finalization-start-new-verification": "Start Ny Verifikasjon",
     "finalization-email-success": "✅ Verifikasjonssammendrag sendt vellykket til {email}",
     "finalization-email-error": "Mislyktes å sende e-post. Vennligst prøv igjen.",

--- a/public/lang/pl.json
+++ b/public/lang/pl.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Wprowadź adres email",
     "finalization-send-email": "Wyślij Email",
     "finalization-sending": "Wysyłanie...",
-    "finalization-print-summary": "Drukuj Podsumowanie",
     "finalization-start-new-verification": "Rozpocznij Nową Weryfikację",
     "finalization-email-success": "✅ Podsumowanie weryfikacji wysłane pomyślnie na {email}",
     "finalization-email-error": "Wysłanie email nieudane. Spróbuj ponownie.",

--- a/public/lang/pt.json
+++ b/public/lang/pt.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Digite o endereço de email",
     "finalization-send-email": "Enviar Email",
     "finalization-sending": "Enviando...",
-    "finalization-print-summary": "Imprimir Resumo",
     "finalization-start-new-verification": "Iniciar Nova Verificação",
     "finalization-email-success": "✅ Resumo de verificação enviado com sucesso para {email}",
     "finalization-email-error": "Falha ao enviar email. Por favor, tente novamente.",

--- a/public/lang/ro.json
+++ b/public/lang/ro.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Introduceți adresa de email",
     "finalization-send-email": "Trimite email",
     "finalization-sending": "Se trimite...",
-    "finalization-print-summary": "Printează rezumatul",
     "finalization-start-new-verification": "Începe o nouă verificare",
     "finalization-email-success": "✅ Rezumatul verificării trimis cu succes la {email}",
     "finalization-email-error": "Trimiterea emailului a eșuat. Vă rugăm să încercați din nou.",

--- a/public/lang/sk.json
+++ b/public/lang/sk.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Zadajte e-mailovú adresu",
     "finalization-send-email": "Odoslať e-mail",
     "finalization-sending": "Odosielam...",
-    "finalization-print-summary": "Vytlačiť zhrnutie",
     "finalization-start-new-verification": "Začať novú verifikáciu",
     "finalization-email-success": "✅ Zhrnutie verifikácie úspešne odoslané na {email}",
     "finalization-email-error": "Nepodarilo sa odoslať e-mail. Prosím skúste znovu.",

--- a/public/lang/sl.json
+++ b/public/lang/sl.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Vnesite e-poštni naslov",
     "finalization-send-email": "Pošlji e-pošto",
     "finalization-sending": "Pošiljam...",
-    "finalization-print-summary": "Natisni povzetek",
     "finalization-start-new-verification": "Začni novo preverjanje",
     "finalization-email-success": "✅ Povzetek preverjanja uspešno poslan na {email}",
     "finalization-email-error": "Pošiljanje e-pošte neuspešno. Prosimo, poskusite znova.",

--- a/public/lang/sv.json
+++ b/public/lang/sv.json
@@ -144,7 +144,6 @@
     "finalization-enter-email": "Ange e-postadress",
     "finalization-send-email": "Skicka E-post",
     "finalization-sending": "Skickar...",
-    "finalization-print-summary": "Skriv ut Sammanfattning",
     "finalization-start-new-verification": "Starta Ny Verifiering",
     "finalization-email-success": "✅ Verifieringssammanfattning skickad framgångsrikt till {email}",
     "finalization-email-error": "Misslyckades att skicka e-post. Vänligen försök igen.",

--- a/views/finalization.ejs
+++ b/views/finalization.ejs
@@ -77,7 +77,6 @@
             </div>
 
             <div class="controls">
-                <button id="print-summary" class="btn btn-secondary" data-i18n-key="finalization-print-summary">Print Summary</button>
                 <button id="print-pdf" class="btn btn-success" data-i18n-key="finalization-print-pdf">Print PDF</button>
                 <button id="print-pdf-bilingual" class="btn btn-success" data-i18n-key="finalization-print-pdf-bilingual" style="display: none;">Print PDF (Bilingual)</button>
                 <button id="download-pdf" class="btn btn-info" data-i18n-key="finalization-download-pdf">Download PDF</button>


### PR DESCRIPTION
## Summary
Remove the "Print Summary" button from the finalization page as requested in issue #42. This provides a more controlled printing experience while preserving structured PDF generation capabilities.

## Changes Made
- ✅ **Removed Print Summary Button**: Eliminated the "Print Summary" button from finalization page controls
- ✅ **Removed JavaScript Functionality**: Removed the `window.print()` event listener 
- ✅ **Translation Cleanup**: Removed `finalization-print-summary` key from all 27 language files
- ✅ **Preserved PDF Features**: Print PDF and Download PDF buttons remain fully functional

## Impact
- **Before**: Users could print the entire webpage using a simple "Print Summary" button
- **After**: Users can only print via structured PDF generation (Print PDF button)
- **Benefit**: More professional and controlled printing experience with properly formatted verification documents

## Files Modified
- `views/finalization.ejs` - Removed print summary button from HTML
- `public/js/finalization.js` - Removed print event listener  
- `public/lang/*.json` (27 files) - Removed orphaned translation keys

## Test plan
- [x] Verify "Print Summary" button no longer appears on finalization page
- [x] Confirm "Print PDF" and "Download PDF" buttons still work correctly
- [x] Test that no JavaScript errors occur when page loads
- [x] Verify translations still work for remaining buttons
- [x] Check that page layout remains intact after button removal

## Screenshots
The finalization page now shows only the essential action buttons:
- Print PDF / Print PDF (Bilingual)
- Download PDF / Download PDF (Bilingual)  
- Start New Verification

Resolves #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)