### PR TITLE
Fix Treatment Date Range Validation severity level

### DIFF
--- a/routes/scanRoutes.js
+++ b/routes/scanRoutes.js
@@ -7451,7 +7451,7 @@ async function processVerificationData(originalData, treatmentDate = null) {
                                 });
 
                                 // Set status based on validation result
-                                const rangeStatus = !treatmentDate ? 'skipped' : (treatmentDateRangeValidationPassed ? 'success' : 'warning');
+                                const rangeStatus = !treatmentDate ? 'skipped' : (treatmentDateRangeValidationPassed ? 'success' : 'error');
                                 validationSummary.treatmentDateRange = {
                                     status: rangeStatus,
                                     message: treatmentDateRangeValidationMessage


### PR DESCRIPTION
## Summary
- Fixes Treatment Date Range Validation severity level from warning to error when treatment date falls outside certificate validity period
- Ensures that invalid treatment date ranges properly cause overall verification failure instead of just showing a warning

## Problem
The Treatment Date Range Validation was incorrectly set to return a 'warning' status when the treatment date fell outside the certificate validity period. This meant that invalid treatment dates would not cause the overall verification to fail, which is incorrect behavior for a critical validation.

## Solution
- Modified `routes/scanRoutes.js` line 7454 to change validation status from 'warning' to 'error'
- When treatment date falls outside certificate validity period (not between startDate and endDate), validation now properly shows as error
- Maintains existing behavior for other cases:
  - 'skipped' when no treatment date is provided
  - 'success' when treatment date is within valid range

## Technical Details
**File**: `routes/scanRoutes.js:7454`
**Before**: `const rangeStatus = !treatmentDate ? 'skipped' : (treatmentDateRangeValidationPassed ? 'success' : 'warning');`
**After**: `const rangeStatus = !treatmentDate ? 'skipped' : (treatmentDateRangeValidationPassed ? 'success' : 'error');`

## Test plan
- [ ] Test with treatment date before certificate start date (should show error)
- [ ] Test with treatment date after certificate end date (should show error)
- [ ] Test with treatment date within certificate validity period (should show success)
- [ ] Test with no treatment date provided (should show skipped)
- [ ] Verify that error status causes overall verification failure
- [ ] Confirm error appears correctly in PDF and email reports

## Impact
- Critical validation logic fix ensuring proper error handling
- Improves verification reliability by properly failing invalid treatment dates
- No breaking changes to API or user interface
- Maintains backward compatibility for valid scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)