### PR TITLE
Fix Scan History button visibility in production mode (Resolves #75)

### DIFF
--- a/views/auth/profile.ejs
+++ b/views/auth/profile.ejs
@@ -27,9 +27,11 @@
                             <a href="/" class="btn btn-outline-primary btn-sm mb-2">
                                 <i class="bi bi-house"></i> <span data-i18n-key="nav-home">Home</span>
                             </a>
+                            <% if (typeof isDebugMode !== 'undefined' && isDebugMode) { %>
                             <a href="/scan-history" class="btn btn-outline-primary btn-sm">
                                 <i class="bi bi-clock-history"></i> <span data-i18n-key="nav-history">Scan History</span>
                             </a>
+                            <% } %>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Fixes issue #75 where the "Scan History" button was visible in production mode on the `/auth/profile` page
- Hides the button in production mode while keeping it visible in debug mode
- Maintains consistent behavior with the existing navbar implementation

## Problem
The "Scan History" button on the profile page (`/auth/profile`) was always visible regardless of the application mode. According to the application design, scan history functionality should only be available in debug mode, not in production mode.

## Solution
- Added conditional rendering using `<% if (typeof isDebugMode !== 'undefined' && isDebugMode) { %>`
- Applied the same pattern already used in `views/partials/navbar.ejs` for consistency
- Ensures the button is only displayed when the application is running in DEBUG mode

## Technical Details
**File**: `views/auth/profile.ejs` (lines 30-34)
**Before**: Button always visible
**After**: Button conditionally rendered based on debug mode

```ejs
<% if (typeof isDebugMode !== 'undefined' && isDebugMode) { %>
<a href="/scan-history" class="btn btn-outline-primary btn-sm">
    <i class="bi bi-clock-history"></i> <span data-i18n-key="nav-history">Scan History</span>
</a>
<% } %>
```

## Behavior
- **DEBUG Mode**: ✅ "Scan History" button is visible and functional  
- **PRODUCTION Mode**: ✅ "Scan History" button is hidden (not displayed)

## Test plan
- [ ] Test profile page in DEBUG mode - verify "Scan History" button is visible
- [ ] Test profile page in PRODUCTION mode - verify "Scan History" button is hidden
- [ ] Verify existing functionality remains unchanged
- [ ] Confirm navigation works correctly in debug mode
- [ ] Test responsive design on mobile devices

## Impact
- Fixes production mode UI inconsistency
- Maintains debug mode functionality for development
- No breaking changes to existing functionality
- Consistent with application mode-based feature visibility

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)