### PR TITLE
Implement Forgot Password Page Internationalization (Issue #81)

### DIFF
--- a/public/lang/bg.json
+++ b/public/lang/bg.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Паролите не съвпадат!",
     "register-password-length-alert": "Паролата трябва да бъде поне 6 знака!",
 
+    "forgot-password-title": "Нулиране на парола",
+    "forgot-password-instruction": "Въведете вашия имейл адрес и ще ви изпратим връзка за нулиране на паролата.",
+    "forgot-password-email-label": "Имейл адрес",
+    "forgot-password-submit-button": "Изпращане на връзка за нулиране",
+    "forgot-password-back-to-login": "Назад към вход",
+    "forgot-password-email-placeholder": "Въведете вашия имейл",
+
     "landing-breadcrumb-welcome": "Добре дошли",
     "landing-breadcrumb-treatment-date": "Дата на лечението",
     "landing-breadcrumb-visual-verification": "Визуална проверка",

--- a/public/lang/cs.json
+++ b/public/lang/cs.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Hesla se neshodují!",
     "register-password-length-alert": "Heslo musí mít alespoň 6 znaků!",
 
+    "forgot-password-title": "Obnovení hesla",
+    "forgot-password-instruction": "Zadejte svou e-mailovou adresu a my vám zašleme odkaz pro obnovení hesla.",
+    "forgot-password-email-label": "E-mailová adresa",
+    "forgot-password-submit-button": "Odeslat odkaz pro obnovení",
+    "forgot-password-back-to-login": "Zpět na přihlášení",
+    "forgot-password-email-placeholder": "Zadejte svůj e-mail",
+
     "landing-breadcrumb-welcome": "Vítejte",
     "landing-breadcrumb-treatment-date": "Datum léčby",
     "landing-breadcrumb-visual-verification": "Vizuální ověření",

--- a/public/lang/da.json
+++ b/public/lang/da.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Adgangskoder matcher ikke!",
     "register-password-length-alert": "Adgangskode skal være mindst 6 tegn lang!",
 
+    "forgot-password-title": "Nulstil adgangskode",
+    "forgot-password-instruction": "Indtast din e-mailadresse, og vi sender dig et link til at nulstille din adgangskode.",
+    "forgot-password-email-label": "E-mailadresse",
+    "forgot-password-submit-button": "Send nulstillingslink",
+    "forgot-password-back-to-login": "Tilbage til login",
+    "forgot-password-email-placeholder": "Indtast din e-mail",
+
     "landing-breadcrumb-welcome": "Velkommen",
     "landing-breadcrumb-treatment-date": "Behandlingsdato",
     "landing-breadcrumb-visual-verification": "Visuel verifikation",

--- a/public/lang/de.json
+++ b/public/lang/de.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Passwörter stimmen nicht überein!",
     "register-password-length-alert": "Passwort muss mindestens 6 Zeichen lang sein!",
 
+    "forgot-password-title": "Passwort zurücksetzen",
+    "forgot-password-instruction": "Geben Sie Ihre E-Mail-Adresse ein und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts.",
+    "forgot-password-email-label": "E-Mail-Adresse",
+    "forgot-password-submit-button": "Zurücksetzungslink senden",
+    "forgot-password-back-to-login": "Zurück zur Anmeldung",
+    "forgot-password-email-placeholder": "Geben Sie Ihre E-Mail ein",
+
     "landing-breadcrumb-welcome": "Willkommen",
     "landing-breadcrumb-treatment-date": "Behandlungsdatum",
     "landing-breadcrumb-visual-verification": "Sichtprüfung",

--- a/public/lang/el.json
+++ b/public/lang/el.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Οι κωδικοί πρόσβασης δεν ταιριάζουν!",
     "register-password-length-alert": "Ο κωδικός πρόσβασης πρέπει να έχει τουλάχιστον 6 χαρακτήρες!",
 
+    "forgot-password-title": "Επαναφορά κωδικού πρόσβασης",
+    "forgot-password-instruction": "Εισαγάγετε τη διεύθυνση email σας και θα σας στείλουμε έναν σύνδεσμο για επαναφορά του κωδικού πρόσβασης.",
+    "forgot-password-email-label": "Διεύθυνση email",
+    "forgot-password-submit-button": "Αποστολή συνδέσμου επαναφοράς",
+    "forgot-password-back-to-login": "Επιστροφή στη σύνδεση",
+    "forgot-password-email-placeholder": "Εισαγάγετε το email σας",
+
     "landing-breadcrumb-welcome": "Καλώς ήλθατε",
     "landing-breadcrumb-treatment-date": "Ημερομηνία θεραπείας",
     "landing-breadcrumb-visual-verification": "Οπτική επαλήθευση",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Passwords do not match!",
     "register-password-length-alert": "Password must be at least 6 characters long!",
 
+    "forgot-password-title": "Reset Password",
+    "forgot-password-instruction": "Enter your email address and we'll send you a link to reset your password.",
+    "forgot-password-email-label": "Email Address",
+    "forgot-password-submit-button": "Send Reset Link",
+    "forgot-password-back-to-login": "Back to Login",
+    "forgot-password-email-placeholder": "Enter your email",
+
     "landing-breadcrumb-welcome": "Welcome",
     "landing-breadcrumb-treatment-date": "Treatment Date",
     "landing-breadcrumb-visual-verification": "Visual Verification",

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "¡Las contraseñas no coinciden!",
     "register-password-length-alert": "¡La contraseña debe tener al menos 6 caracteres!",
 
+    "forgot-password-title": "Restablecer contraseña",
+    "forgot-password-instruction": "Ingrese su dirección de correo electrónico y le enviaremos un enlace para restablecer su contraseña.",
+    "forgot-password-email-label": "Dirección de correo electrónico",
+    "forgot-password-submit-button": "Enviar enlace de restablecimiento",
+    "forgot-password-back-to-login": "Volver al inicio de sesión",
+    "forgot-password-email-placeholder": "Ingrese su correo electrónico",
+
     "landing-breadcrumb-welcome": "Bienvenido",
     "landing-breadcrumb-treatment-date": "Fecha de tratamiento",
     "landing-breadcrumb-visual-verification": "Verificación visual",

--- a/public/lang/et.json
+++ b/public/lang/et.json
@@ -44,6 +44,13 @@
     "register-password-mismatch-alert": "Paroolid ei ühti!",
     "register-password-length-alert": "Parool peab olema vähemalt 6 tähemärki pikk!",
 
+    "forgot-password-title": "Parooli lähtestamine",
+    "forgot-password-instruction": "Sisestage oma e-posti aadress ja me saadame teile parooli lähtestamise lingi.",
+    "forgot-password-email-label": "E-posti aadress",
+    "forgot-password-submit-button": "Saada lähtestamislink",
+    "forgot-password-back-to-login": "Tagasi sisselogimisse",
+    "forgot-password-email-placeholder": "Sisesta oma e-post",
+
     "landing-breadcrumb-welcome": "Tere tulemast",
     "landing-breadcrumb-treatment-date": "Ravi kuupäev",
     "landing-breadcrumb-visual-verification": "Visuaalne kontroll",

--- a/public/lang/fi.json
+++ b/public/lang/fi.json
@@ -44,6 +44,13 @@
     "register-password-mismatch-alert": "Salasanat eivät täsmää!",
     "register-password-length-alert": "Salasanan on oltava vähintään 6 merkkiä pitkä!",
 
+    "forgot-password-title": "Nollaa salasana",
+    "forgot-password-instruction": "Syötä sähköpostiosoitteesi ja lähetämme sinulle linkin salasanan nollaamiseksi.",
+    "forgot-password-email-label": "Sähköpostiosoite",
+    "forgot-password-submit-button": "Lähetä nollauslinkki",
+    "forgot-password-back-to-login": "Takaisin kirjautumiseen",
+    "forgot-password-email-placeholder": "Syötä sähköpostisi",
+
     "landing-breadcrumb-welcome": "Tervetuloa",
     "landing-breadcrumb-treatment-date": "Hoitopäivä",
     "landing-breadcrumb-visual-verification": "Visuaalinen vahvistus",

--- a/public/lang/fr.json
+++ b/public/lang/fr.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Les mots de passe ne correspondent pas !",
     "register-password-length-alert": "Le mot de passe doit comporter au moins 6 caractères !",
 
+    "forgot-password-title": "Réinitialiser le mot de passe",
+    "forgot-password-instruction": "Entrez votre adresse e-mail et nous vous enverrons un lien pour réinitialiser votre mot de passe.",
+    "forgot-password-email-label": "Adresse e-mail",
+    "forgot-password-submit-button": "Envoyer le lien de réinitialisation",
+    "forgot-password-back-to-login": "Retour à la connexion",
+    "forgot-password-email-placeholder": "Entrez votre e-mail",
+
     "landing-breadcrumb-welcome": "Bienvenue",
     "landing-breadcrumb-treatment-date": "Date de traitement",
     "landing-breadcrumb-visual-verification": "Vérification visuelle",

--- a/public/lang/fy.json
+++ b/public/lang/fy.json
@@ -44,6 +44,13 @@
     "register-password-mismatch-alert": "Wachtwurden komme net oerien!",
     "register-password-length-alert": "Wachtwurd moat op syn minst 6 tekens lang wêze!",
 
+    "forgot-password-title": "Wachtwurd opnij ynstelle",
+    "forgot-password-instruction": "Fier jo e-postadres yn en wy stjoere jo in keppeling om jo wachtwurd opnij yn te stellen.",
+    "forgot-password-email-label": "E-postadres",
+    "forgot-password-submit-button": "Stjoer keppeling foar opnij ynstellen",
+    "forgot-password-back-to-login": "Werom nei ynlogge",
+    "forgot-password-email-placeholder": "Fier jo e-post yn",
+
     "landing-breadcrumb-welcome": "Wolkom",
     "landing-breadcrumb-treatment-date": "Behannelingsdatum",
     "landing-breadcrumb-visual-verification": "Fisuele Ferifikaasje",

--- a/public/lang/ga.json
+++ b/public/lang/ga.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Ní thagann na pasfhocail!",
     "register-password-length-alert": "Ní mór don phasfhocal a bheith 6 charachtar ar a laghad!",
 
+    "forgot-password-title": "Athshocraigh Pasfhocal",
+    "forgot-password-instruction": "Cuir isteach do sheoladh ríomhphoist agus seolfaimid nasc chugat chun do phasfhocal a athshocrú.",
+    "forgot-password-email-label": "Seoladh Ríomhphoist",
+    "forgot-password-submit-button": "Seol Nasc Athshocraithe",
+    "forgot-password-back-to-login": "Ar Ais go Logáil Isteach",
+    "forgot-password-email-placeholder": "Cuir isteach do ríomhphost",
+
     "landing-breadcrumb-welcome": "Fáilte",
     "landing-breadcrumb-treatment-date": "Dáta Cóireála",
     "landing-breadcrumb-visual-verification": "Fíorú Amhairc",

--- a/public/lang/hr.json
+++ b/public/lang/hr.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Lozinke se ne podudaraju!",
     "register-password-length-alert": "Lozinka mora biti duga najmanje 6 znakova!",
 
+    "forgot-password-title": "Ponovno postavi lozinku",
+    "forgot-password-instruction": "Unesite svoju e-mail adresu i poslat ćemo vam poveznicu za ponovno postavljanje lozinke.",
+    "forgot-password-email-label": "E-mail adresa",
+    "forgot-password-submit-button": "Pošalji poveznicu za ponovno postavljanje",
+    "forgot-password-back-to-login": "Natrag na prijavu",
+    "forgot-password-email-placeholder": "Unesite svoju e-mail adresu",
+
     "landing-breadcrumb-welcome": "Dobrodošli",
     "landing-breadcrumb-treatment-date": "Datum liječenja",
     "landing-breadcrumb-visual-verification": "Vizualna provjera",

--- a/public/lang/hu.json
+++ b/public/lang/hu.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "A jelszavak nem egyeznek!",
     "register-password-length-alert": "A jelszónak legalább 6 karakter hosszúnak kell lennie!",
 
+    "forgot-password-title": "Jelszó visszaállítása",
+    "forgot-password-instruction": "Adja meg e-mail címét és küldünk egy linket a jelszó visszaállításához.",
+    "forgot-password-email-label": "E-mail cím",
+    "forgot-password-submit-button": "Visszaállítási link küldése",
+    "forgot-password-back-to-login": "Vissza a bejelentkezéshez",
+    "forgot-password-email-placeholder": "Adja meg e-mail címét",
+
     "landing-breadcrumb-welcome": "Üdvözöljük",
     "landing-breadcrumb-treatment-date": "Kezelés dátuma",
     "landing-breadcrumb-visual-verification": "Vizuális hitelesítés",

--- a/public/lang/is.json
+++ b/public/lang/is.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Lykilorð passa ekki saman!",
     "register-password-length-alert": "Lykilorð þarf að vera að minnsta kosti 6 stafir að lengd!",
 
+    "forgot-password-title": "Endurstilla lykilorð",
+    "forgot-password-instruction": "Sláðu inn netfangið þitt og við munum senda þér tengil til að endurstilla lykilorðið þitt.",
+    "forgot-password-email-label": "Netfang",
+    "forgot-password-submit-button": "Senda endurstillingartengil",
+    "forgot-password-back-to-login": "Til baka í innskráningu",
+    "forgot-password-email-placeholder": "Sláðu inn netfangið þitt",
+
     "landing-breadcrumb-welcome": "Velkomin",
     "landing-breadcrumb-treatment-date": "Meðferðardagur",
     "landing-breadcrumb-visual-verification": "Sjónræn staðfesting",

--- a/public/lang/it.json
+++ b/public/lang/it.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Le password non corrispondono!",
     "register-password-length-alert": "La password deve essere lunga almeno 6 caratteri!",
 
+    "forgot-password-title": "Reimposta password",
+    "forgot-password-instruction": "Inserisci il tuo indirizzo email e ti invieremo un link per reimpostare la tua password.",
+    "forgot-password-email-label": "Indirizzo email",
+    "forgot-password-submit-button": "Invia link di reimpostazione",
+    "forgot-password-back-to-login": "Torna all'accesso",
+    "forgot-password-email-placeholder": "Inserisci la tua email",
+
     "landing-breadcrumb-welcome": "Benvenuto",
     "landing-breadcrumb-treatment-date": "Data del trattamento",
     "landing-breadcrumb-visual-verification": "Verifica visiva",

--- a/public/lang/lt.json
+++ b/public/lang/lt.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Slaptažodžiai nesutampa!",
     "register-password-length-alert": "Slaptažodis turi būti mažiausiai 6 simbolių!",
 
+    "forgot-password-title": "Atstatyti slaptažodį",
+    "forgot-password-instruction": "Įveskite savo el. pašto adresą ir mes atsiųsime jums nuorodą slaptažodžio atstatymui.",
+    "forgot-password-email-label": "El. pašto adresas",
+    "forgot-password-submit-button": "Siųsti atstatymo nuorodą",
+    "forgot-password-back-to-login": "Atgal į prisijungimą",
+    "forgot-password-email-placeholder": "Įveskite savo el. paštą",
+
     "landing-breadcrumb-welcome": "Sveiki atvykę",
     "landing-breadcrumb-treatment-date": "Gydymo data",
     "landing-breadcrumb-visual-verification": "Vizualinis patikrinimas",

--- a/public/lang/lv.json
+++ b/public/lang/lv.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Paroles nesakrīt!",
     "register-password-length-alert": "Parolei jābūt vismaz 6 rakstzīmes!",
 
+    "forgot-password-title": "Atjaunot paroli",
+    "forgot-password-instruction": "Ievadiet savu e-pasta adresi, un mēs nosūtīsim jums saiti paroles atjaunošanai.",
+    "forgot-password-email-label": "E-pasta adrese",
+    "forgot-password-submit-button": "Nosūtīt atjaunošanas saiti",
+    "forgot-password-back-to-login": "Atpakaļ uz pieteikšanos",
+    "forgot-password-email-placeholder": "Ievadiet savu e-pastu",
+
     "landing-breadcrumb-welcome": "Laipni lūdzam",
     "landing-breadcrumb-treatment-date": "Ārstēšanas datums",
     "landing-breadcrumb-visual-verification": "Vizuālā verifikācija",

--- a/public/lang/mt.json
+++ b/public/lang/mt.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Il-passwords ma jaqblux!",
     "register-password-length-alert": "Il-password trid tkun mill-inqas 6 karattri!",
 
+    "forgot-password-title": "Irrisettja l-Password",
+    "forgot-password-instruction": "Daħħal l-indirizz tal-email tiegħek u se nibagħtulek link biex tirrisettja l-password tiegħek.",
+    "forgot-password-email-label": "Indirizz tal-email",
+    "forgot-password-submit-button": "Ibgħat Link ta' Rissettjar",
+    "forgot-password-back-to-login": "Lura għall-Login",
+    "forgot-password-email-placeholder": "Daħħal l-email tiegħek",
+
     "landing-breadcrumb-welcome": "Merħba",
     "landing-breadcrumb-treatment-date": "Data tal-Kura",
     "landing-breadcrumb-visual-verification": "Verifikazzjoni Viżwali",

--- a/public/lang/nl.json
+++ b/public/lang/nl.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Wachtwoorden komen niet overeen!",
     "register-password-length-alert": "Wachtwoord moet minimaal 6 tekens lang zijn!",
 
+    "forgot-password-title": "Wachtwoord opnieuw instellen",
+    "forgot-password-instruction": "Voer uw e-mailadres in en wij sturen u een link om uw wachtwoord opnieuw in te stellen.",
+    "forgot-password-email-label": "E-mailadres",
+    "forgot-password-submit-button": "Herstelkoppeling verzenden",
+    "forgot-password-back-to-login": "Terug naar inloggen",
+    "forgot-password-email-placeholder": "Voer uw e-mailadres in",
+
     "landing-breadcrumb-welcome": "Welkom",
     "landing-breadcrumb-treatment-date": "Behandeldatum",
     "landing-breadcrumb-visual-verification": "Visuele verificatie",

--- a/public/lang/no.json
+++ b/public/lang/no.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Passordene stemmer ikke overens!",
     "register-password-length-alert": "Passordet må være minst 6 tegn langt!",
 
+    "forgot-password-title": "Tilbakestill passord",
+    "forgot-password-instruction": "Skriv inn e-postadressen din, så sender vi deg en lenke for å tilbakestille passordet ditt.",
+    "forgot-password-email-label": "E-postadresse",
+    "forgot-password-submit-button": "Send tilbakestillingslenke",
+    "forgot-password-back-to-login": "Tilbake til innlogging",
+    "forgot-password-email-placeholder": "Skriv inn din e-post",
+
     "landing-breadcrumb-welcome": "Velkommen",
     "landing-breadcrumb-treatment-date": "Behandlingsdato",
     "landing-breadcrumb-visual-verification": "Visuell verifisering",

--- a/public/lang/pl.json
+++ b/public/lang/pl.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Hasła nie pasują do siebie!",
     "register-password-length-alert": "Hasło musi mieć co najmniej 6 znaków!",
 
+    "forgot-password-title": "Zresetuj hasło",
+    "forgot-password-instruction": "Wprowadź swój adres e-mail, a wyślemy Ci link do zresetowania hasła.",
+    "forgot-password-email-label": "Adres e-mail",
+    "forgot-password-submit-button": "Wyślij link resetujący",
+    "forgot-password-back-to-login": "Powrót do logowania",
+    "forgot-password-email-placeholder": "Wprowadź swój adres e-mail",
+
     "landing-breadcrumb-welcome": "Witaj",
     "landing-breadcrumb-treatment-date": "Data leczenia",
     "landing-breadcrumb-visual-verification": "Weryfikacja wizualna",

--- a/public/lang/pt.json
+++ b/public/lang/pt.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "As senhas não correspondem!",
     "register-password-length-alert": "A senha deve ter pelo menos 6 caracteres!",
 
+    "forgot-password-title": "Redefinir senha",
+    "forgot-password-instruction": "Digite seu endereço de e-mail e enviaremos um link para redefinir sua senha.",
+    "forgot-password-email-label": "Endereço de e-mail",
+    "forgot-password-submit-button": "Enviar link de redefinição",
+    "forgot-password-back-to-login": "Voltar ao login",
+    "forgot-password-email-placeholder": "Digite seu e-mail",
+
     "landing-breadcrumb-welcome": "Bem-vindo",
     "landing-breadcrumb-treatment-date": "Data do tratamento",
     "landing-breadcrumb-visual-verification": "Verificação visual",

--- a/public/lang/ro.json
+++ b/public/lang/ro.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Parolele nu se potrivesc!",
     "register-password-length-alert": "Parola trebuie să aibă cel puțin 6 caractere!",
 
+    "forgot-password-title": "Resetare parolă",
+    "forgot-password-instruction": "Introduceți adresa dvs. de e-mail și vă vom trimite un link pentru a vă reseta parola.",
+    "forgot-password-email-label": "Adresă de e-mail",
+    "forgot-password-submit-button": "Trimiteți linkul de resetare",
+    "forgot-password-back-to-login": "Înapoi la autentificare",
+    "forgot-password-email-placeholder": "Introduceți adresa dvs. de e-mail",
+
     "landing-breadcrumb-welcome": "Bine ați venit",
     "landing-breadcrumb-treatment-date": "Data tratamentului",
     "landing-breadcrumb-visual-verification": "Verificare vizuală",

--- a/public/lang/sk.json
+++ b/public/lang/sk.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Heslá sa nezhodujú!",
     "register-password-length-alert": "Heslo musí mať aspoň 6 znakov!",
 
+    "forgot-password-title": "Obnovenie hesla",
+    "forgot-password-instruction": "Zadajte svoju emailovú adresu a my vám pošleme odkaz na obnovenie hesla.",
+    "forgot-password-email-label": "Emailová adresa",
+    "forgot-password-submit-button": "Odoslať odkaz na obnovenie",
+    "forgot-password-back-to-login": "Späť na prihlásenie",
+    "forgot-password-email-placeholder": "Zadajte svoj email",
+
     "landing-breadcrumb-welcome": "Vitajte",
     "landing-breadcrumb-treatment-date": "Dátum liečby",
     "landing-breadcrumb-visual-verification": "Vizuálne overenie",

--- a/public/lang/sl.json
+++ b/public/lang/sl.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Gesli se ne ujemata!",
     "register-password-length-alert": "Geslo mora biti dolgo vsaj 6 znakov!",
 
+    "forgot-password-title": "Ponastavitev gesla",
+    "forgot-password-instruction": "Vnesite svoj e-poštni naslov in poslali vam bomo povezavo za ponastavitev gesla.",
+    "forgot-password-email-label": "E-poštni naslov",
+    "forgot-password-submit-button": "Pošlji povezavo za ponastavitev",
+    "forgot-password-back-to-login": "Nazaj na prijavo",
+    "forgot-password-email-placeholder": "Vnesite svoj e-poštni naslov",
+
     "landing-breadcrumb-welcome": "Dobrodošli",
     "landing-breadcrumb-treatment-date": "Datum zdravljenja",
     "landing-breadcrumb-visual-verification": "Vizualno preverjanje",

--- a/public/lang/sv.json
+++ b/public/lang/sv.json
@@ -45,6 +45,13 @@
     "register-password-mismatch-alert": "Lösenorden matchar inte!",
     "register-password-length-alert": "Lösenordet måste vara minst 6 tecken långt!",
 
+    "forgot-password-title": "Återställ lösenord",
+    "forgot-password-instruction": "Ange din e-postadress så skickar vi dig en länk för att återställa ditt lösenord.",
+    "forgot-password-email-label": "E-postadress",
+    "forgot-password-submit-button": "Skicka återställningslänk",
+    "forgot-password-back-to-login": "Tillbaka till inloggning",
+    "forgot-password-email-placeholder": "Ange din e-postadress",
+
     "landing-breadcrumb-welcome": "Välkommen",
     "landing-breadcrumb-treatment-date": "Behandlingsdatum",
     "landing-breadcrumb-visual-verification": "Visuell verifiering",

--- a/views/auth/forgot-password.ejs
+++ b/views/auth/forgot-password.ejs
@@ -50,12 +50,36 @@
             font-weight: 600;
             font-size: 16px;
         }
+        .language-selector-container {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            z-index: 1000;
+        }
+        #languageSelector {
+            background-color: rgba(255,255,255,0.1);
+            border: 1px solid rgba(255,255,255,0.2);
+            color: white;
+            border-radius: 8px;
+            padding: 8px 12px;
+            font-size: 14px;
+            min-width: 120px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        #languageSelector:focus {
+            border-color: rgba(255,255,255,0.4);
+            box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.25);
+        }
+        #languageSelector option {
+            background-color: #10b981;
+            color: white;
+        }
     </style>
 </head>
 <body>
     <div class="forgot-container">
         <div class="forgot-header">
-            <h1><i class="bi bi-key"></i> Reset Password</h1>
+            <h1><i class="bi bi-key"></i> <span data-i18n-key="forgot-password-title">Reset Password</span></h1>
         </div>
         <div class="forgot-body">
             <% if (typeof error !== 'undefined' && error) { %>
@@ -70,11 +94,11 @@
                 </div>
             <% } %>
 
-            <p class="text-muted mb-4">Enter your email address and we'll send you a link to reset your password.</p>
+            <p class="text-muted mb-4" data-i18n-key="forgot-password-instruction">Enter your email address and we'll send you a link to reset your password.</p>
 
-            <form method="POST" action="/auth/forgot-password">
+            <form method="POST" action="/auth/forgot-password" id="forgotPasswordForm">
                 <div class="mb-3">
-                    <label for="email" class="form-label">Email Address</label>
+                    <label for="email" class="form-label" data-i18n-key="forgot-password-email-label">Email Address</label>
                     <div class="input-group">
                         <span class="input-group-text"><i class="bi bi-envelope"></i></span>
                         <input type="email" class="form-control" id="email" name="email" required
@@ -84,17 +108,80 @@
 
                 <div class="d-grid mb-3">
                     <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-send"></i> Send Reset Link
+                        <i class="bi bi-send"></i> <span data-i18n-key="forgot-password-submit-button">Send Reset Link</span>
                     </button>
                 </div>
 
                 <div class="text-center">
-                    <a href="/auth/login">Back to Login</a>
+                    <a href="/auth/login" data-i18n-key="forgot-password-back-to-login">Back to Login</a>
                 </div>
             </form>
+
+            <!-- Hidden element for JavaScript translation -->
+            <span data-i18n-key="forgot-password-email-placeholder" style="display: none;">Enter your email</span>
         </div>
     </div>
 
+    <!-- Language Selector (positioned at top right) -->
+    <div class="language-selector-container">
+        <select id="languageSelector" class="form-select form-select-sm">
+            <option value="en">English</option>
+            <option value="bg">Български</option>
+            <option value="cs">Čeština</option>
+            <option value="da">Dansk</option>
+            <option value="de">Deutsch</option>
+            <option value="et">Eesti</option>
+            <option value="el">Ελληνικά</option>
+            <option value="es">Español</option>
+            <option value="fr">Français</option>
+            <option value="fy">Frysk</option>
+            <option value="ga">Gaeilge</option>
+            <option value="hr">Hrvatski</option>
+            <option value="is">Íslenska</option>
+            <option value="it">Italiano</option>
+            <option value="lv">Latviešu</option>
+            <option value="lt">Lietuvių</option>
+            <option value="hu">Magyar</option>
+            <option value="mt">Malti</option>
+            <option value="nl">Nederlands</option>
+            <option value="no">Norsk</option>
+            <option value="pl">Polski</option>
+            <option value="pt">Português</option>
+            <option value="ro">Română</option>
+            <option value="sk">Slovenčina</option>
+            <option value="sl">Slovenščina</option>
+            <option value="fi">Suomi</option>
+            <option value="sv">Svenska</option>
+        </select>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/manageLocale.js"></script>
+    <script>
+        // Function to update placeholder text with translations
+        function updatePlaceholders() {
+            const emailInput = document.getElementById('email');
+            const emailPlaceholder = document.querySelector('[data-i18n-key="forgot-password-email-placeholder"]')?.textContent || 'Enter your email';
+
+            if (emailInput) {
+                emailInput.placeholder = emailPlaceholder;
+            }
+        }
+
+        // Update placeholders when page loads
+        document.addEventListener('DOMContentLoaded', function() {
+            // Wait a bit for translations to load
+            setTimeout(updatePlaceholders, 100);
+        });
+
+        // Override the language selector change to also update placeholders
+        const originalLanguageSelector = document.getElementById('languageSelector');
+        if (originalLanguageSelector) {
+            originalLanguageSelector.addEventListener('change', function() {
+                // Wait for translations to be applied
+                setTimeout(updatePlaceholders, 100);
+            });
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ✅ Added complete internationalization support to the forgot-password page
- ✅ Added data-i18n-key attributes to all fixed text elements
- ✅ Added forgot-password translation keys to all 27 language files
- ✅ Implemented language selector with consistent design
- ✅ Added JavaScript for dynamic placeholder translation

## Problem Solved
Fixed issue #81 where the forgot-password.ejs page had fixed text without data-i18n-key attributes, preventing translation in different languages.

## Changes Made

### 1. Forgot-Password Page Modifications (`views/auth/forgot-password.ejs`)
- Added `data-i18n-key` attributes to all 6 fixed text elements:
  - Header title: "Reset Password"
  - Instruction text: "Enter your email address and we'll send you a link to reset your password."
  - Email address label: "Email Address"
  - Submit button: "Send Reset Link"
  - Back to login link: "Back to Login"
  - Email placeholder: "Enter your email"
- Integrated language selector with consistent styling matching login/register pages
- Included manageLocale.js script for translation functionality
- Added JavaScript to dynamically translate email input field placeholder
- Enhanced form structure with proper ID for JavaScript integration

### 2. Translation Keys Added (All 27 Language Files)
Added 6 new translation keys to all language files:
- `forgot-password-title`: "Reset Password"
- `forgot-password-instruction`: Complete instruction text about email and reset link
- `forgot-password-email-label`: "Email Address"
- `forgot-password-submit-button`: "Send Reset Link"
- `forgot-password-back-to-login`: "Back to Login"
- `forgot-password-email-placeholder`: "Enter your email"

### 3. Language Support
Complete translations added for all 27 European languages:
- **EU**: Bulgarian, Czech, Danish, German, Estonian, Greek, Spanish, French, Croatian, Italian, Latvian, Lithuanian, Hungarian, Maltese, Dutch, Polish, Portuguese, Romanian, Slovak, Slovenian, Finnish, Swedish
- **EEA**: Norwegian, Icelandic
- **Regional**: Irish Gaelic, West Frisian
- **Base**: English

### 4. Example Translations
**German:**
- "Passwort zurücksetzen"
- "Geben Sie Ihre E-Mail-Adresse ein und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts."
- "Zurücksetzungslink senden"

**Italian:**
- "Reimposta password"
- "Inserisci il tuo indirizzo email e ti invieremo un link per reimpostare la tua password."
- "Invia link di reimpostazione"

**French:**
- "Réinitialiser le mot de passe"
- "Entrez votre adresse e-mail et nous vous enverrons un lien pour réinitialiser votre mot de passe."
- "Envoyer le lien de réinitialisation"

## Technical Implementation

### Language Selector Integration
- Positioned language selector in top-right corner with fixed positioning
- Applied semi-transparent styling matching main application design
- Included all 27 language options with native language names

### Dynamic Placeholder Translation
- Implemented `updatePlaceholders()` function for email field
- Added event listeners for page load and language changes
- Provided fallback support with English defaults
- Real-time updates when language is changed

### Professional Terminology
- Used healthcare/government appropriate terminology for password reset
- Clear, professional instruction text for security-sensitive operations
- Consistent terminology across all supported languages

## Test Plan
- [x] Verify forgot-password page loads with English defaults
- [x] Test language selector functionality across all 27 languages
- [x] Confirm all text elements translate correctly
- [x] Validate email placeholder text updates dynamically
- [x] Check instruction text displays appropriately in all languages
- [x] Test form submission works with all translations
- [x] Verify consistent design with login/register pages

## Result
The forgot-password page now provides complete internationalization support, allowing users to reset their passwords in any of the 27 supported European languages with professional, clear instructions and culturally appropriate terminology.

This completes the authentication page internationalization trilogy:
1. ✅ Login page internationalization (Issue #40)
2. ✅ Register page internationalization (Issue #78)
3. ✅ Forgot password page internationalization (Issue #81)

🤖 Generated with [Claude Code](https://claude.com/claude-code)